### PR TITLE
feat: 게시물 상세 정보 조회 기능 구현

### DIFF
--- a/FE/lib/bindings/post_binding.dart
+++ b/FE/lib/bindings/post_binding.dart
@@ -1,0 +1,20 @@
+import 'package:get/get.dart';
+
+import '../services/api_service.dart';
+import '../services/token_service.dart';
+
+import '../controllers/post_controller.dart';
+
+class PostBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<ApiService>(() => ApiService());
+    Get.lazyPut<TokenService>(() => TokenService());
+    Get.lazyPut<PostController>(() => PostController(
+      apiService: Get.find(),
+      tokenService: Get.find(),
+    ));
+
+  }
+
+}

--- a/FE/lib/controllers/post_controller.dart
+++ b/FE/lib/controllers/post_controller.dart
@@ -1,0 +1,44 @@
+import 'package:get/get.dart';
+
+import '../models/post_model.dart';
+import '../services/api_service.dart';
+import '../services/token_service.dart';
+
+class PostController extends GetxController {
+  final ApiService apiService;
+  final TokenService tokenService;
+  PostController({required this.apiService, required this.tokenService});
+
+  final post = Post(
+    id: 0,
+    userId: 0,
+    privacyId: 0,
+    weaveId: 0,
+    thumbnailMediaId: 0,
+    textContent: '',
+    location: '',
+    areaId: 0,
+    likes: 0,
+    createdAt: '',
+    updatedAt: '',
+    weaveTitle: '',
+    nickname: '',
+    userMediaUrl: '',
+    subValid: 0,
+    commentCount: 0,
+    mediaUrl: '',
+    weaveType: 0,
+  ).obs;
+
+  Future<void> fetchPost(int postId) async {
+    try {
+      String userId = await tokenService.loadUserId();
+      var response = await apiService.postRequest('PostInfo', {'post_id': postId, 'user_id': userId});
+      final Post fetchedPost = Post.fromJson(response);
+      post.value = fetchedPost;
+    } catch (e) {
+      print('Error fetching post: $e');
+    }
+  }
+
+}

--- a/FE/lib/views/post_view.dart
+++ b/FE/lib/views/post_view.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+
+import '../controllers/post_controller.dart';
+
+class PostView extends GetPage<PostController> {
+  PostView({required super.name, required super.page});
+
+
+}


### PR DESCRIPTION
- `post_controller.dart`: 게시물 상세 정보 조회 기능을 구현했습니다.
- `post_binding.dart`: PostController에 대한 의존성 주입 설정을 추가했습니다.
- `post_view.dart`: PostController를 사용하는 GetPage를 생성했습니다.