### PR TITLE
refactor: 위브 생성 시 지도에서 위도/경도 설정 기능 파일명 변경

### DIFF
--- a/FE/lib/controllers/search_controller.dart
+++ b/FE/lib/controllers/search_controller.dart
@@ -28,15 +28,13 @@ class WeaveSearchController extends GetxController {
   final RxList<JoinWeave> joinWeaveData = <JoinWeave>[].obs;
   final mapMarkers = <NMarker>{}.obs;
 
-  late Worker _debouncer;
-
   WeaveSearchController({required this.locationService});
 
   @override
   void onInit() {
     super.onInit();
     getRecentLocation();
-    _debouncer = debounce(
+    debounce(
       RxString(''),
       (_) => search(textController.text),
       time: const Duration(milliseconds: 500),
@@ -151,13 +149,18 @@ class WeaveSearchController extends GetxController {
         'weave/join/get/area', {'user_id': userId, 'area_ids': areaId});
     joinWeaveData.value =
         (response['weaves'] as List).map((e) => JoinWeave.fromJson(e)).toList();
-    print(joinWeaveData.length);
-    print(response['weaves']);
     mapMarkers.assignAll(joinWeaveData.map((group) {
-      return NMarker(
+      final marker = NMarker(
         id: group.weaveId.toString(),
         position: NLatLng(group.lat, group.lng),
       );
+      marker.setOnTapListener((NMarker marker) {
+        Get.toNamed('/new_post', arguments: {
+          'weaveId': group.weaveId,
+          'weaveTitle': group.title,
+        });
+      });
+      return marker;
     }));
     mapLoading.value = false;
   }

--- a/FE/lib/views/owner_nav/owner_new_weave_view.dart
+++ b/FE/lib/views/owner_nav/owner_new_weave_view.dart
@@ -6,7 +6,7 @@ import '../widgets/new_weave_widget/new_name.input.dart';
 import '../widgets/new_weave_widget/weave_explanation.dart';
 import '../widgets/reward_invite_dialog.dart';
 import '../widgets/owner_reward_post_widgets/reward_selector_widget.dart';
-import 'test_set_latlng_on_map.dart';
+import 'set_latlng_on_map.dart';
 
 class OwnerNewWeaveView extends GetView<OwnerNewWeaveController> {
   const OwnerNewWeaveView({super.key});

--- a/FE/lib/views/owner_nav/set_latlng_on_map.dart
+++ b/FE/lib/views/owner_nav/set_latlng_on_map.dart
@@ -20,7 +20,6 @@ class MapSelectPin extends StatelessWidget {
         // position이 null일 때는 로딩 인디케이터를 표시
         return const Center(child: CircularProgressIndicator());
       }
-
       return Column(
         children: [
           SizedBox(

--- a/FE/lib/views/widgets/search_widgets/map_section.dart
+++ b/FE/lib/views/widgets/search_widgets/map_section.dart
@@ -38,6 +38,7 @@ class MapSection extends StatelessWidget {
                   // final marker = NMarker(id: "test", position: NLatLng(controller.position.value!.latitude, controller.position.value!.longitude));
                   r.addOverlayAll(controller.mapMarkers);
                 }
+
             ),
           ),
           if (hasResults) ...[


### PR DESCRIPTION
- `test_set_latlng_on_map.dart` -> `set_latlng_on_map.dart`

feat: 검색 결과 지도에서 마커 탭 시 해당 위브의 글쓰기 화면으로 이동 기능 추가

- `SearchController`에서 마커 생성 시 `setOnTapListener`를 통해 글쓰기 화면으로 이동 로직 추가